### PR TITLE
"get own recipes" endpoint

### DIFF
--- a/apps/backend/src/domains/users/controller.ts
+++ b/apps/backend/src/domains/users/controller.ts
@@ -11,6 +11,7 @@ import {
 
 import HttpError from '../../helpers/HttpError.js';
 
+import type { OwnRecipeQuery } from './service.js';
 import * as service from './service.js';
 
 export async function createUser(req: Request, res: Response) {
@@ -48,6 +49,15 @@ export async function getUserDetails(req: Request, res: Response) {
   const user = await service.getUserDetails(userId, currentUserId);
 
   res.status(200).json(user);
+}
+
+export async function getUserRecipes(req: Request, res: Response) {
+  const { userId } = req.params;
+  const query = req.query as OwnRecipeQuery;
+
+  const recipes = await service.getUserRecipes(userId, query);
+
+  res.status(200).json(recipes);
 }
 
 export async function getUserFollowers(req: Request, res: Response) {

--- a/apps/backend/src/domains/users/router.ts
+++ b/apps/backend/src/domains/users/router.ts
@@ -37,6 +37,12 @@ router.get(
 );
 
 router.get(
+  '/:userId/recipes',
+  authenticate,
+  catchErrors(controller.getUserRecipes),
+);
+
+router.get(
   '/:userId/followers',
   authenticate,
   catchErrors(controller.getUserFollowers),

--- a/apps/backend/src/domains/users/service.ts
+++ b/apps/backend/src/domains/users/service.ts
@@ -8,6 +8,7 @@ import type {
   CreateUserPayload,
   CreateUserResponse,
   CurrentUserDetails,
+  GetPaginatedRecipeShort,
   LoginUserPayload,
   LoginUserResponse,
   OtherUserDetails,
@@ -18,6 +19,7 @@ import type {
 import {
   CreateUserResponseSchema,
   CurrentUserDetailsSchema,
+  GetRecipeShortSchema,
   JwtUserSchema,
   LoginUserResponseSchema,
   OtherUserDetailsSchema,
@@ -38,6 +40,11 @@ type UserQuery =
   | Pick<UserSchemaAttributes, 'email'>
   | Pick<UserSchemaAttributes, 'id'>
   | Pick<UserSchemaAttributes, 'email' | 'id'>;
+
+export type OwnRecipeQuery = {
+  page?: string | number;
+  perPage?: string | number;
+};
 
 export async function findUser(
   query: UserQuery,
@@ -148,6 +155,31 @@ export async function getUserDetails(
         favoriteRecipesCount,
         followersCount,
       });
+}
+
+export async function getUserRecipes(
+  userId: string,
+  query: OwnRecipeQuery,
+): Promise<GetPaginatedRecipeShort> {
+  // Pagination
+  const limit = query.perPage ? Number(query.perPage) : 10;
+  const page = query.page ? Number(query.page) : 1;
+  const offset = (page - 1) * limit;
+
+  const { count, rows: items } = await RecipeDTO.findAndCountAll({
+    where: { userId },
+    limit,
+    offset,
+    order: [['updatedAt', 'DESC']],
+  });
+
+  const totalPages = Math.ceil(count / limit);
+
+  return {
+    items: GetRecipeShortSchema.array().parse(items),
+    page,
+    totalPages,
+  } as GetPaginatedRecipeShort;
 }
 
 export async function getUserFollowers(

--- a/libs/schemas/src/schemas/Recipe.ts
+++ b/libs/schemas/src/schemas/Recipe.ts
@@ -42,14 +42,33 @@ export const GetRecipeResponseSchema = RecipeSchema.pick({
 
 export type GetRecipeResponse = z.infer<typeof GetRecipeResponseSchema>;
 
+export const GetRecipeShortSchema = RecipeSchema.pick({
+  id: true,
+  title: true,
+  thumb: true,
+  description: true,
+});
+
+export type GetRecipeShort = z.infer<typeof GetRecipeShortSchema>;
+
+export const GetPaginatedRecipeShortSchema = z.object({
+  page: z.number(),
+  totalPages: z.number(),
+  items: z.array(GetRecipeResponseSchema.pick({})),
+});
+
+export type GetPaginatedRecipeShort = z.infer<
+  typeof GetPaginatedRecipeShortSchema
+>;
+
 export const GetRecipeListResponseSchema = z.array(GetRecipeResponseSchema);
 
 export type GetRecipeListResponse = z.infer<typeof GetRecipeListResponseSchema>;
 
 export const GetPaginatedRecipeResponseSchema = z.object({
-  items: GetRecipeListResponseSchema,
   page: z.number(),
   totalPages: z.number(),
+  items: GetRecipeListResponseSchema,
 });
 
 export type GetPaginatedRecipeResponse = z.infer<


### PR DESCRIPTION
The endpoint takes own recipes (or recipes for other users) using same dynamic path parameter `userId`

Examples of request:
Own recipes:
`GET /api/users/64c8d958249fae54bae90bc2/recipes?page=2&perPage=2`

Other user recipes:
`GET /api/users/64c8d958249fae54bae90bc3/recipes?page=2&perPage=2`

Query pagination parameters are optional.
Default values:
- page=1
- perPage=10

Response looks same for own/other users

Example of request own recipes `GET /api/users/64c8d958249fae54bae90bc3/recipes?page=2&perPage=2`
```
{
    "items": [
        {
            "id": "6462a8f74c3d0ddd2889804c",
            "title": "Pate Chinois",
            "thumb": "https://ftp.goit.study/img/so-yummy/preview/Pate%20Chinois.jpg",
            "description": "A French-Canadian dish made with layers of ground beef, corn, and mashed potatoes, baked in a casserole dish until golden brown."
        },
        {
            "id": "6462a8f74c3d0ddd28898043",
            "title": "General Tso's Chicken",
            "thumb": "https://ftp.goit.study/img/so-yummy/preview/General%20Tso_s%20Chicken.jpg",
            "description": "A popular Chinese-American dish made with crispy fried chicken in a sweet and spicy sauce. Served with rice."
        }
    ],
    "page": 2,
    "totalPages": 23
}
```