### PR TITLE
Add 'get favorite user recipes' endpoint

### DIFF
--- a/apps/backend/src/domains/users/controller.ts
+++ b/apps/backend/src/domains/users/controller.ts
@@ -60,6 +60,15 @@ export async function getUserRecipes(req: Request, res: Response) {
   res.status(200).json(recipes);
 }
 
+export async function getUserFavorites(req: Request, res: Response) {
+  const { id: userId } = req.user as UserSchemaAttributes;
+  const query = req.query as OwnRecipeQuery;
+
+  const favorites = await service.getUserFavorites(userId, query);
+
+  res.status(200).json(favorites);
+}
+
 export async function getUserFollowers(req: Request, res: Response) {
   const { userId } = req.params;
 

--- a/apps/backend/src/domains/users/router.ts
+++ b/apps/backend/src/domains/users/router.ts
@@ -43,6 +43,12 @@ router.get(
 );
 
 router.get(
+  '/favorites',
+  authenticate,
+  catchErrors(controller.getUserFavorites),
+);
+
+router.get(
   '/:userId/followers',
   authenticate,
   catchErrors(controller.getUserFollowers),


### PR DESCRIPTION
The private endpoint returns current logged in user's favorite recipes.

Request: `GET /api/users/favorites?page=1&perPage=2` for user `64c8d958249fae54bae90bc1`

Response:
```
{
    "items": [
        {
            "id": "6462a8f74c3d0ddd288980a5",
            "title": "Bigos (Hunters Stew)",
            "thumb": "https://ftp.goit.study/img/so-yummy/preview/Bigos%20_Hunters%20Stew_.jpg",
            "description": ""
        },
        {
            "id": "6462a8f74c3d0ddd28897fc0",
            "title": "Vegan Lasagna",
            "thumb": "https://ftp.goit.study/img/so-yummy/preview/Vegan%20Lasagna.jpg",
            "description": "A plant-based version of the classic Italian dish, made with layers of pasta, tomato sauce, vegan cheese, and vegetables (such as spinach, zucchini, and mushrooms)."
        }
    ],
    "page": 1,
    "totalPages": 3
}
```