### PR TITLE
refactor: remove lazy loading from category images

### DIFF
--- a/apps/frontend/src/components/modules/Categories/CategoryList/CategoryList.tsx
+++ b/apps/frontend/src/components/modules/Categories/CategoryList/CategoryList.tsx
@@ -20,7 +20,6 @@ const CategoryList = ({ categories, onCategorySelect }: CategoryListProps) => {
       {categories.slice(0, limit).map((category, index) => (
         <li key={index} className={styles.categoryCard}>
           <img
-            loading="lazy"
             src={category.images?.small}
             srcSet={`${category.images?.small} 320w, ${category.images?.medium} 768w, ${category.images?.large} 1440w`} // Define the responsive sizes
             sizes="(max-width: 375px) 320px, 


### PR DESCRIPTION
PageSpeed finding: 

<img width="940" alt="зображення" src="https://github.com/user-attachments/assets/b0df0c28-3258-414c-a680-d8ae34c9c97f" />
